### PR TITLE
Update CITATION.cff with ApJ pub info

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,11 +58,11 @@ identifiers:
     value: "10.5281/zenodo.8159145"
 preferred-citation:
   type: "article"
-  date-released: "2023-06-23"
+  date-released: "2023-10-10"
   title: "Observations of the Crab Nebula and Pulsar with the Large-Sized Telescope Prototype of the Cherenkov Telescope Array"
-  doi: "10.48550/arXiv.2306.12960"
-  journal: "arXiv"
-  month: 7
+  doi: "10.3847/1538-4357/ace89d"
+  journal: "The Astrophysical Journal"
+  month: 10
   year: 2023
   authors:
     - family-names: "CTA-LST Project"


### PR DESCRIPTION
Changed `preferred-citation` from arXiv to ApJ information.
@vuillaut  Not sure about how I should change the indentifier field though. Currently points to the zenodo entry that compiles all versions
